### PR TITLE
Removed unused require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var jwt        = require('jsonwebtoken')
 var expressJwt = require('express-jwt')
 var stampit    = require('stampit')
-var _          = require('lodash')
 
 module.exports = stampit()
   .refs({


### PR DESCRIPTION
Lodash is currently not used, as a consequence when you install the package with npm we get an error message 

```
Error: Cannot find module 'lodash'
```
